### PR TITLE
Update to Clojure 1.9.0-alpha17 and Clojurescript 1.9.562.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
                  [org.clojure/spec.alpha "0.1.109"]
                  [org.clojure/clojurescript "1.9.562"]
                  [org.clojure/core.async "0.3.442"]
-                 [com.cerner/clara-rules "0.15.0"]
+                 [com.cerner/clara-rules "0.15.0" :exclusions [prismatic/schema]]
+                 [prismatic/schema "1.1.6"]
                  [reagent "0.6.0"]]
 
   :plugins [[lein-cljsbuild "1.1.4"]

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,9 @@
   :url          "https://github.com/CoNarrative/precept.git"
   :license      {:name "MIT"
                  :url "https://github.com/CoNarrative/precept/blob/master/LICENSE"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha15"]
-                 [org.clojure/clojurescript "1.9.494"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
+                 [org.clojure/spec.alpha "0.1.109"]
+                 [org.clojure/clojurescript "1.9.562"]
                  [org.clojure/core.async "0.3.442"]
                  [com.cerner/clara-rules "0.15.0"]
                  [reagent "0.6.0"]]

--- a/src/clj/precept/macros.clj
+++ b/src/clj/precept/macros.clj
@@ -9,7 +9,7 @@
               [precept.spec.sub :as sub]
               [precept.util :as util]
               [precept.schema :as schema]
-              [clojure.spec :as s]
+              [clojure.spec.alpha :as s]
               [clara.rules :as cr]))
 
 (defn trace [& args]

--- a/src/clj/precept/spec/core.cljc
+++ b/src/clj/precept/spec/core.cljc
@@ -1,5 +1,5 @@
 (ns precept.spec.core
-  (:require [clojure.spec :as s]))
+  (:require [clojure.spec.alpha :as s]))
 
 (defn validate [spec value]
   (let [msg (s/explain-str spec value)]

--- a/src/clj/precept/spec/error.cljc
+++ b/src/clj/precept/spec/error.cljc
@@ -1,5 +1,5 @@
 (ns precept.spec.error
-  (:require [clojure.spec :as s]))
+  (:require [clojure.spec.alpha :as s]))
 
 
 (s/def ::unique-identity-conflict string?)

--- a/src/clj/precept/spec/lang.cljc
+++ b/src/clj/precept/spec/lang.cljc
@@ -1,5 +1,5 @@
 (ns precept.spec.lang
-    (:require [clojure.spec :as s]
+    (:require [clojure.spec.alpha :as s]
               [precept.spec.rulegen :as rulegen]))
 
 (s/def ::variable-binding

--- a/src/clj/precept/spec/rulegen.cljc
+++ b/src/clj/precept/spec/rulegen.cljc
@@ -1,5 +1,5 @@
 (ns precept.spec.rulegen
-  (:require [clojure.spec :as s]))
+  (:require [clojure.spec.alpha :as s]))
 
 
 (s/def ::generators #{'entities})

--- a/src/clj/precept/spec/sub.cljc
+++ b/src/clj/precept/spec/sub.cljc
@@ -1,5 +1,5 @@
 (ns precept.spec.sub
-  (:require [clojure.spec :as s]))
+  (:require [clojure.spec.alpha :as s]))
 
 (s/def ::name keyword?)
 

--- a/src/clj/precept/spec/test.cljc
+++ b/src/clj/precept/spec/test.cljc
@@ -1,5 +1,5 @@
 (ns precept.spec.test
-  (:require [clojure.spec :as s]))
+  (:require [clojure.spec.alpha :as s]))
 
 (s/def ::unique-identity any?)
 

--- a/test/clj/precept/lang_test.clj
+++ b/test/clj/precept/lang_test.clj
@@ -1,8 +1,8 @@
 (ns precept.lang-test
     (:require [clojure.test :refer [deftest is testing run-tests]]
               [precept.spec.lang :as lang]
-              [clojure.spec :as s]
-              [clojure.spec.gen :as gen]))
+              [clojure.spec.alpha :as s]
+              [clojure.spec.gen.alpha :as gen]))
 
 (deftest lang-test
   (testing "Variable binding"

--- a/test/clj/precept/util_test.cljc
+++ b/test/clj/precept/util_test.cljc
@@ -9,7 +9,7 @@
               [precept.schema-fixture :refer [test-schema]]
               [clara.tools.inspect :as inspect]
               [clara.tools.tracing :as trace]
-              [clojure.spec :as s]
+              [clojure.spec.alpha :as s]
               [precept.spec.test :as test]
               [precept.spec.error :as err]
               [clara.rules :refer [query defquery fire-rules] :as cr]

--- a/test/cljc/precept/core_test.cljc
+++ b/test/cljc/precept/core_test.cljc
@@ -11,7 +11,7 @@
             [precept.schema :as schema]
             [precept.schema-fixture :refer [test-schema]]
             [clara.rules :as cr]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [precept.test-helpers :as h]
     #?(:clj [clojure.test :refer [use-fixtures deftest is testing run-tests]]))
   (:import [precept.util Tuple]))


### PR DESCRIPTION
This PR unblocks those of us using the latest Clojure alpha release.