### PR TITLE
Issue 78: Add support for predicate functions in value slot

### DIFF
--- a/src/clj/precept/spec/core.cljc
+++ b/src/clj/precept/spec/core.cljc
@@ -7,7 +7,7 @@
       "Success!\n" true
       (ex-info msg {}))))
 
-(defn some-conform
+(defn conform-or-nil
   "Takes a spec and x, a collection or value to test. If x is coll, returns first item in
   coll that conforms to spec or nil. If x is not a collection returns x if it conforms to spec
   or nil."

--- a/src/clj/precept/spec/core.cljc
+++ b/src/clj/precept/spec/core.cljc
@@ -6,3 +6,13 @@
     (condp = msg
       "Success!\n" true
       (ex-info msg {}))))
+
+(defn some-conform
+  "Takes a spec and x, a collection or value to test. If x is coll, returns first item in
+  coll that conforms to spec or nil. If x is not a collection returns x if it conforms to spec
+  or nil."
+  [spec x]
+  (some
+    (comp #(when-not (= :clojure.spec/invalid %) %)
+          #(s/conform spec %))
+    (if (coll? x) x (vector x))))

--- a/src/clj/precept/spec/lang.cljc
+++ b/src/clj/precept/spec/lang.cljc
@@ -12,6 +12,13 @@
 
 (s/def ::ignore-slot #{"_" '_})
 
+(s/def ::boolean-s-expr-ops #{'> '< '>= '<=})
+
+(s/def ::boolean-s-expr
+  (s/and ::s-expr
+    #(s/valid? ::boolean-s-expr-ops (first %))
+    #(some (fn [x] (s/valid? ::variable-binding x)) %)))
+
 (s/def ::value-equals-matcher
   (s/and some?
     #(not (coll? %))

--- a/src/clj/precept/spec/lang.cljc
+++ b/src/clj/precept/spec/lang.cljc
@@ -12,11 +12,8 @@
 
 (s/def ::ignore-slot #{"_" '_})
 
-(s/def ::boolean-s-expr-ops #{'> '< '>= '<=})
-
-(s/def ::boolean-s-expr
+(s/def ::s-expr-with-binding
   (s/and ::s-expr
-    #(s/valid? ::boolean-s-expr-ops (first %))
     #(some (fn [x] (s/valid? ::variable-binding x)) %)))
 
 (s/def ::value-equals-matcher

--- a/test/clj/precept/lang_test.clj
+++ b/test/clj/precept/lang_test.clj
@@ -37,7 +37,7 @@
     (is (s/valid? ::lang/tuple-2 '[?e :foo]))
     (is (s/valid? ::lang/tuple-2 '[1 :foo]))
     (is (s/valid? ::lang/tuple-2 '["x" :foo]))
-    (is (not (s/valid? ::lang/tuple-2 '[?e "foo"])))
+    (is (s/valid? ::lang/tuple-2 '[?e "foo"]))
     (is (not (s/valid? ::lang/tuple-2 '[?e :foo "bar"]))))
   (testing "Tuple-3"
     (is (s/valid? ::lang/tuple-3 '[?e :foo "bar"]))
@@ -51,7 +51,7 @@
     (is (s/valid? ::lang/tuple-4 '[?e :foo "bar" ?tx-id]))
     (is (s/valid? ::lang/tuple-4 '[_ :foo _ ?tx-id]))
     (is (not (s/valid? ::lang/tuple-4 '[?e :foo "bar" _])))
-    (is (not (s/valid? ::lang/tuple-4 '[_ _ _ ?tx-id]))))
+    (is (s/valid? ::lang/tuple-4 '[_ _ _ ?tx-id])))
   (testing "Tuple"
     (is (s/valid? ::lang/tuple '[?e :foo]))
     (is (s/valid? ::lang/tuple '[?e :foo "bar"]))

--- a/test/clj/precept/lang_test.clj
+++ b/test/clj/precept/lang_test.clj
@@ -16,6 +16,7 @@
     (is (not (s/valid? ::lang/variable-binding '['?e :kw 2]))))
   (testing "S-expression"
     (is (s/valid? ::lang/s-expr '(= foo true)))
+    (is (s/valid? ::lang/s-expr '(> 42 ?foo)))
     (is (not (s/valid? ::lang/s-expr '[= foo true])))
     (is (not (s/valid? ::lang/s-expr '{:foo true})))
     (is (not (s/valid? ::lang/s-expr "foo"))))

--- a/test/clj/precept/rule_test.cljc
+++ b/test/clj/precept/rule_test.cljc
@@ -83,6 +83,17 @@
             [:attr-4 (= ?e (:e this)) (= ?v (:v this))]
             [:attr-5 (= ?e (:e this)) (= ?v (:v this))]]])))
 
+(deftest parse-bool-sexpr-test
+  (is (= (macros/parse-bool-sexpr '(> 42 ?v))
+        '[(> 42 (:v this)) (= ?v (:v this))]))
+  (is (= (macros/parse-bool-sexpr '(> ?v 42))
+        '[(> (:v this) 42) (= ?v (:v this))])))
+
+(deftest sexprs-with-bindings-test
+  (is (= (:v (macros/sexprs-with-bindings '[?e :attr (> 42 ?v)]))
+         '[(> 42 (:v this)) (= ?v (:v this))]))
+  (is (= (:v (macros/sexprs-with-bindings '[?e :attr (> ?v 42)]))
+        '[(> (:v this) 42) (= ?v (:v this))])))
 
 (deftest rewrite-lhs-test
   (testing "Ops - :exists, :not, :and, :or"

--- a/test/clj/precept/rule_test.cljc
+++ b/test/clj/precept/rule_test.cljc
@@ -101,7 +101,10 @@
     (is (= '[[?toggle <- :ui/toggle-complete]]
           (rewrite-lhs '[[?toggle <- [:ui/toggle-complete]]])))
     (is (= '[[:not [:ns/foo (= 3 (:v this))]]]
-           (rewrite-lhs '[[:not [_ :ns/foo 3]]])))))
+           (rewrite-lhs '[[:not [_ :ns/foo 3]]]))))
+  (testing "S-expr in value slot"
+    (is (= '[[:attr (> 42 (:v this)) (= ?v (:v this))]]
+           (rewrite-lhs '[[[_ :attr (> 42 ?v)]]])))))
 
 (deftest rule-test
   (testing "Basic rule with exists"
@@ -262,7 +265,18 @@
                      [?fact <- :all (= ?v (:v this)) (= :this-tick (:e this))]
                      =>
                      (trace "CLEANING this-tick fact because transient" ?fact)
-                     (cr/retract! ?fact))))))))
+                     (cr/retract! ?fact)))))))
+  (testing "Greater than (>) in value position"
+    (is (= (macroexpand
+             '(rule my-rule
+                [[_ :attr (> 42 ?v)]]
+                =>
+                (cr/insert! ?fact)))
+          `(do ~(macroexpand
+                  '(defrule my-rule
+                     [:attr (> 42 (:v this)) (= ?v (:v this))]
+                     =>
+                     (cr/insert! ?fact))))))))
 
 (deftest defquery-test
   (testing "Query with no args"

--- a/test/cljc/precept/rules_debug.cljc
+++ b/test/cljc/precept/rules_debug.cljc
@@ -60,11 +60,15 @@
 ;  =>
 ;  (println "Found error!" ?error))
 ;
+;(rule greater-than-42
+;  [[_ :interesting-fact (> ?v 42)]]
+;  =>
+;  (println "Greater than 42:" ?v))
 ;
 ;(session app-session
 ;   'precept.todomvc.rules-debug
 ;   :db-schema db-schema)
-;;(reset! precept.state/fact-index {})
+;(reset! precept.state/fact-index {})
 ;
 ;(-> app-session
 ;  (l/replace-listener)
@@ -77,6 +81,7 @@
 ;                [2 :interesting-fact 42]
 ;                [3 :interesting-fact 42]
 ;                [4 :interesting-fact 42]
+;                [4 :interesting-fact 43]
 ;                [2 :todo/title "Second"]
 ;                [3 :todo/title "Second"]
 ;                [5 ::sub/request :my-sub-2]])

--- a/test/cljc/precept/rules_debug.cljc
+++ b/test/cljc/precept/rules_debug.cljc
@@ -60,8 +60,26 @@
 ;  =>
 ;  (println "Found error!" ?error))
 ;
-;(rule greater-than-42
-;  [[_ :interesting-fact (> ?v 42)]]
+;(defn foo? [x y] (not= x y))
+;
+;;(rule greater-than-42
+;;  [[_ :interesting-fact (foo? ?v 42)]]
+;;  =>
+;;  (println "Greater than 42:" ?v))
+;
+;(rule find-43
+;  [[_ :interesting-fact 43]]
+;  =>
+;  (insert! [(guid) :the-number 43]))
+;
+;(rule pred-w-bound-variable
+;  [[_ :interesting-fact ?v2]]
+;  [[_ :the-number (< ?v2 ?v1)]]
+;  =>
+;  (println "42s" ?v2))
+;
+;(cr/defrule greater-than-42
+;  [:interesting-fact (= ?v (:v this)) (foo? ?v 42)]
 ;  =>
 ;  (println "Greater than 42:" ?v))
 ;


### PR DESCRIPTION
- Implemented and added tests for > < comparisons in value slot of tuple to achieve parity with Clara:
```clj
(rule greater-than-42
  [[_ :interesting-fact (> ?v 42)]]
  =>
  (println "Greater than 42:" ?v))
```
http://www.clara-rules.org/docs/booleans

Having a hard time figuring out from their documentation if they also support >= <= comparisons, and how exactly that is implemented. Looking at this now I'm wondering if their support for > < is special in any way, or if it is simply made possible by their support for Clojure functions in general.

Edit: Appears Clara supports any arbitrary predicate fn instead of > < etc. Further, correct parsing becomes difficult. Further, I don't think we currently to have a way to infer the intent behind `?v` in the example above. The intent could be "run the pred with ?v bound to the value of this slot" or "run the pred with ?v where ?v is a variable bound from a previous expression." In the case the variable is not previously bound, we would expand to:
```clj
[:interesting-fact (> ?v 42) (= ?v (:v this))]
```
If the variable is previously bound, the correct expansion is:
```clj
[:interesting-fact (> ?v 42)]
```
This seems to require us to maintain a set of variable bindings for the rule as we are going through and parsing each "line" or expression. Then when we get to an sexpr we can check whether `?v` is a member. If it's not in the set, we add the binding (`(= ?v (:v this))`) as we do now for every case. If it is in the set, we can let the sexpr pass through unaltered.

Edit2: @mikegai I'm not sure we can leverage hash joins in the same way Clara does [here](http://www.clara-rules.org/docs/hash_joins/) given our tuple structured data.
```clj
[?existing-record <- ExistingRecordCold (= ?loc location)]
[?colder-temp <- Temperature (= location ?loc) (< temperature (:temperature ?existing-record)))
...
[[?e1 :record-low-temp ?record-low]
[[?e1 :location ?loc]]
[[?e2 :current-temperature (< ?current-temp ?record-low)] 
[[?e2 :location ?loc]]
```
The special indexing created by the expression above seems predicated upon a reference to the `:temperature` key of the ExistingRecordCold record.