### PR TITLE
Issue 82: Support insert entity maps

### DIFF
--- a/src/clj/precept/spec/fact.cljc
+++ b/src/clj/precept/spec/fact.cljc
@@ -1,0 +1,12 @@
+(ns precept.spec.fact
+    (:require [clojure.spec :as s]))
+
+
+(s/def ::entity-map
+  (s/keys :req [:db/id]))
+
+(s/def ::tuple
+  (s/tuple
+    some?
+    keyword?
+    some?))

--- a/src/clj/precept/spec/lang.cljc
+++ b/src/clj/precept/spec/lang.cljc
@@ -61,8 +61,8 @@
     keyword?
     (s/and some? #(not (s/valid? ::s-expr %)))
     (s/and some?
-      (s/or :match-tx-id number?
-            :bind-to-tx-id ::variable-binding))))
+      (s/or :value-match-t number?
+            :bind-to-t ::variable-binding))))
 
 (s/def ::tuple
   (s/or :tuple-2 ::tuple-2

--- a/src/clj/precept/util.cljc
+++ b/src/clj/precept/util.cljc
@@ -96,9 +96,13 @@
   "Transforms entity map to Tuple record
   {a1 v1 a2 v2 :db/id eid} -> [(Tuple eid a1 v1 t)...]"
   [m]
-  (mapv (fn [[k v]] (->Tuple (:db/id m) k v (next-fact-id!)))
+  (reduce
+    (fn [acc [k v]]
+      (if ((@state/ancestors-fn k) :one-to-many)
+        (concat acc (map #(->Tuple (:db/id m) k % (next-fact-id!)) v))
+        (conj acc (->Tuple (:db/id m) k v (next-fact-id!)))))
+    []
     (dissoc m :db/id)))
-
 
 (defn insertable
   "Arguments can be any mixture of vectors and records

--- a/src/cljs/precept/todomvc/core.cljs
+++ b/src/cljs/precept/todomvc/core.cljs
@@ -25,7 +25,7 @@
 (defn mount-components []
   (reagent/render [precept.todomvc.views/app] (.getElementById js/document "app")))
 
-(def facts (into (todo "Hi") (todo "there!")))
+(def facts [(todo "Hi") (todo "there!")])
 
 (defn ^:export main []
   (start! {:session app-session :facts facts})

--- a/src/cljs/precept/todomvc/facts.cljs
+++ b/src/cljs/precept/todomvc/facts.cljs
@@ -11,7 +11,6 @@
 (defn todo-edit [e v] [e :todo/edit v])
 
 (defn todo [title]
-  (let [id (random-uuid)]
-    [[id :todo/title title]
-     [id :todo/done false]]))
-
+  {:db/id (random-uuid)
+   :todo/title title
+   :todo/done false})

--- a/src/cljs/precept/todomvc/facts.cljs
+++ b/src/cljs/precept/todomvc/facts.cljs
@@ -8,8 +8,6 @@
 
 (defn active-count [v] [:global :active-count v])
 
-(defn todo-edit [e v] [e :todo/edit v])
-
 (defn todo [title]
   {:db/id (random-uuid)
    :todo/title title

--- a/test/clj/precept/listeners_test.cljc
+++ b/test/clj/precept/listeners_test.cljc
@@ -43,14 +43,17 @@
 (def background-facts (repeatedly 5 #(vector (guid) :junk 42)))
 
 (deftest trace-parsing-fns
-  (let [traced-session (-> @(session trace-parsing-session)
+  (let [fact-t (inc @state/fact-id)
+        traced-session (-> @(session trace-parsing-session)
                           (l/replace-listener)
                           (util/insert
                             (into
-                              [[1 :attr/a "state-0" 123]
+                              [[1 :attr/a "state-0"]
                                [1 :attr/b "state-0"]]
                               background-facts))
-                          (util/retract [1 :attr/a "state-0" 123])
+                          (util/retract
+                            (->Tuple 1 :attr/a "state-0" fact-t)
+                            #_[1 :attr/a "state-0"])
                           (fire-rules))
         traces (l/fact-traces traced-session)
         keyed-by-type (l/trace-by-type (first traces))

--- a/test/clj/precept/util_test.cljc
+++ b/test/clj/precept/util_test.cljc
@@ -126,6 +126,13 @@
            [{:db/id 1 ::test/one-to-many '(42 42 42 42 42) ::test/one-to-one 42}
             {:db/id 2 ::test/one-to-many '(42 42 42 42 42) ::test/one-to-one 42}]))))
 
+(deftest entity-map->Tuples-test
+  (let [m {:db/id 123 ::test/one-to-one "foo" ::test/one-to-many [42 42 42 42 42]}
+        records (entity-map->Tuples m)]
+    (is (every? #(= Tuple (type %)) records))
+    (is (= 1 (count (filter #(= ::test/one-to-one (:a %)) records))))
+    (is (= 5 (count (filter #(= ::test/one-to-many (:a %)) records))))))
+
 (deftest insertable-test
   (testing "Single vector"
     (let [rtn (insertable [-1 :attr "foo"])]


### PR DESCRIPTION
- Insert Datomic-style entity maps using the syntax outlined in #82
- Added `precept.spec.facts` to help with validation of the different fact data structures we support
- If one of the map's attributes is a collection, and the attribute is in the schema as `:one-to-many`, we insert a tuple for each item in the list