### PR TITLE
Issue 85: Support bound variable in attribute slot of accum match

### DIFF
--- a/src/clj/precept/spec/lang.cljc
+++ b/src/clj/precept/spec/lang.cljc
@@ -47,18 +47,18 @@
 (s/def ::tuple-2
   (s/tuple
     (s/and some? #(not (s/valid? ::s-expr %)))
-    keyword?))
+    any?))
 
 (s/def ::tuple-3
   (s/tuple
     (s/and some? #(not (s/valid? ::s-expr %)))
-    keyword?
+    any?
     (s/and some? #(not (s/valid? ::s-expr %)))))
 
 (s/def ::tuple-4
   (s/tuple
     (s/and some? #(not (s/valid? ::s-expr %)))
-    keyword?
+    any?
     (s/and some? #(not (s/valid? ::s-expr %)))
     (s/and some?
       (s/or :match-tx-id number?

--- a/test/clj/precept/rule_test.cljc
+++ b/test/clj/precept/rule_test.cljc
@@ -55,7 +55,9 @@
   (is (= '[:ns/attr (= ?tx-id (:t this))]
         (parse-as-tuple '[[_ :ns/attr _ ?tx-id]])))
   (is (= '[:ns/attr (= -1 (:t this))]
-        (parse-as-tuple '[[_ :ns/attr _ -1]]))))
+        (parse-as-tuple '[[_ :ns/attr _ -1]])))
+  (is (= '[:all (= ?a (:a this))]
+         (parse-as-tuple '[[_ ?a]]))))
 
 (deftest parse-with-accumulator-test
   (is (= (macros/parse-with-accumulator '[?entity <- (acc/all) :from [?e :all]])
@@ -63,7 +65,9 @@
   (is (= (macros/parse-with-accumulator '[?entity <- (acc/all :e) :from [?e :all]])
         '[?entity <- (acc/all :e) :from [:all (= ?e (:e this))]]))
   (is (= (macros/parse-with-accumulator '[?entity <- (acc/all) :from [(:e ?v) :all]])
-        '[?entity <- (acc/all) :from [:all (= (:e ?v) (:e this))]])))
+        '[?entity <- (acc/all) :from [:all (= (:e ?v) (:e this))]]))
+  (is (= (macros/parse-with-accumulator '[?x <- (acc/all) :from [_ ?a]])
+        '[?x <- (acc/all) :from [:all (= ?a (:a this))]])))
 
 (deftest parse-with-op-test
   (is (= (macros/parse-with-op '[:or [?e :attr ?v]
@@ -262,7 +266,20 @@
                      [?fact <- :all (= ?v (:v this)) (= :this-tick (:e this))]
                      =>
                      (trace "CLEANING this-tick fact because transient" ?fact)
-                     (cr/retract! ?fact))))))))
+                     (cr/retract! ?fact)))))))
+  (testing "Accumulator with match on attribute"
+    (is (= (macroexpand
+            '(rule dynamic-type
+               [[_ :some-type-name ?attr]]
+               [?x <- (acc/all) :from [_ ?attr]]
+               =>
+               (println "RHS" ?x)))
+          `(do ~(macroexpand
+                  '(defrule dynamic-type
+                    [:some-type-name (= ?attr (:v this))]
+                    [?x <- (acc/all) :from [:all (= ?attr (:a this))]]
+                    =>
+                    (println "RHS" ?x))))))))
 
 (deftest defquery-test
   (testing "Query with no args"

--- a/test/cljc/precept/rules_debug.cljc
+++ b/test/cljc/precept/rules_debug.cljc
@@ -60,6 +60,13 @@
 ;  =>
 ;  (println "Found error!" ?error))
 ;
+;(rule dynamic-type-tuple
+;  [[_ :some-type-name ?attr]]
+;  [?x <- (acc/all :e) :from [_ ?attr]]
+;  [[_ ?attr]]
+;  =>
+;  (println "Attr" ?attr)
+;  (println "eids" ?x))
 ;
 ;(session app-session
 ;   'precept.todomvc.rules-debug
@@ -71,6 +78,7 @@
 ;  (util/insert [[1 :entry/title "First"]
 ;                [1 :entry/title "Second"]
 ;                [2 :todo/title "First"]
+;                [5 :some-type-name :interesting-fact]
 ;                [3 ::sub/request :my-sub]
 ;                [:transient :test "foo"]
 ;                [1 :interesting-fact 42]

--- a/test/cljc/precept/rules_debug.cljc
+++ b/test/cljc/precept/rules_debug.cljc
@@ -68,6 +68,19 @@
 ;  (println "Attr" ?attr)
 ;  (println "eids" ?x))
 ;
+;; https://github.com/cerner/clara-rules/issues/313
+;(cr/defrule variable-binding-in-accumulator
+;  [:the-keyword-e (= ?v (:v this))]
+;  [?xs <- (acc/all ?v) :from [:interesting-fact]]
+;  =>
+;  (println "[variable-binding-in-acc] " ?xs))
+;
+;;(rule variable-binding-in-accumulator
+;;  [[_ :the-keyword-e ?v]]
+;;  [?xs <- (acc/all ?v) :from [_ :interesting-fact]]
+;;  =>
+;;  (println "[variable-binding-in-acc] " ?xs))
+;
 ;(session app-session
 ;   'precept.todomvc.rules-debug
 ;   :db-schema db-schema)
@@ -79,6 +92,7 @@
 ;                [1 :entry/title "Second"]
 ;                [2 :todo/title "First"]
 ;                [5 :some-type-name :interesting-fact]
+;                [6 :the-keyword-e :e]
 ;                [3 ::sub/request :my-sub]
 ;                [:transient :test "foo"]
 ;                [1 :interesting-fact 42]


### PR DESCRIPTION
- Add support for accum syntax described in #85 
- Add failing example of bound variable passed into accumulator as an argument. Throws error because variable cannot be read. Logged as Clara [issue 313](https://github.com/cerner/clara-rules/issues/313):
```clj
[?x <- (acc/all ?v) :from [:todo/title]]
```