### PR TITLE
Issue 91: Bug fixes, improve `fact-index` consistency with facts in session

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <scm>
     <connection>scm:git:git://github.com/CoNarrative/precept.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/CoNarrative/precept.git</developerConnection>
-    <tag>02620e9a0a8f5b01611dd9fbed2fe565b63164f8
+    <tag>01da9348bdb80a30257a5824f8d065ae4972c0d6
 </tag>
     <url>https://github.com/CoNarrative/precept</url>
   </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <scm>
     <connection>scm:git:git://github.com/CoNarrative/precept.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/CoNarrative/precept.git</developerConnection>
-    <tag>4231ef662fd3f07620b3d6b06133986a4b5da651
+    <tag>66ea4bb3eafefaea08b03f00cebc80a34318b5b7
 </tag>
     <url>https://github.com/CoNarrative/precept</url>
   </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <scm>
     <connection>scm:git:git://github.com/CoNarrative/precept.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/CoNarrative/precept.git</developerConnection>
-    <tag>66ea4bb3eafefaea08b03f00cebc80a34318b5b7
+    <tag>02620e9a0a8f5b01611dd9fbed2fe565b63164f8
 </tag>
     <url>https://github.com/CoNarrative/precept</url>
   </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>precept</groupId>
   <artifactId>precept</artifactId>
   <packaging>jar</packaging>
-  <version>0.3.0-alpha</version>
+  <version>0.3.1-alpha</version>
   <name>precept</name>
   <description>A declarative programming framework</description>
   <url>https://github.com/CoNarrative/precept.git</url>
@@ -16,7 +16,7 @@
   <scm>
     <connection>scm:git:git://github.com/CoNarrative/precept.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/CoNarrative/precept.git</developerConnection>
-    <tag>c11a00dcdf76497e3ce14f66cbcf9a81872783bd
+    <tag>4231ef662fd3f07620b3d6b06133986a4b5da651
 </tag>
     <url>https://github.com/CoNarrative/precept</url>
   </scm>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject precept "0.3.0-alpha"
+(defproject precept "0.3.1-alpha"
   :description "A declarative programming framework"
   :url          "https://github.com/CoNarrative/precept.git"
   :license      {:name "MIT"

--- a/src/clj/precept/listeners.cljc
+++ b/src/clj/precept/listeners.cljc
@@ -26,7 +26,8 @@
     (do
       (println "auto-retracting (no longer supported):" facts)
       (doseq [fact facts]
-        (util/remove-fact-from-index! fact))
+        (when-let [failed-to-remove? (some false? (util/remove-fact-from-index! fact))]
+          (println "Failed to remove " fact)))
       (append-trace listener {:type :retract-facts-logical :facts facts})))
 
   (to-persistent! [listener]

--- a/src/clj/precept/listeners.cljc
+++ b/src/clj/precept/listeners.cljc
@@ -25,8 +25,8 @@
   (retract-facts-logical! [listener node token facts]
     (do
       (println "auto-retracting (no longer supported):" facts)
-      (doseq [x facts]
-        (util/remove-from-fact-index! x (util/fact-index-path x)))
+      (doseq [fact facts]
+        (util/remove-fact-from-index! fact))
       (append-trace listener {:type :retract-facts-logical :facts facts})))
 
   (to-persistent! [listener]

--- a/src/clj/precept/listeners.cljc
+++ b/src/clj/precept/listeners.cljc
@@ -23,7 +23,11 @@
     (append-trace listener {:type :retract-facts :facts facts}))
 
   (retract-facts-logical! [listener node token facts]
-    (append-trace listener {:type :retract-facts-logical :facts facts}))
+    (do
+      (println "auto-retracting (no longer supported):" facts)
+      (doseq [x facts]
+        (util/remove-from-fact-index! x (util/fact-index-path x)))
+      (append-trace listener {:type :retract-facts-logical :facts facts})))
 
   (to-persistent! [listener]
     (PersistentFactListener. @trace))

--- a/src/clj/precept/listeners.cljc
+++ b/src/clj/precept/listeners.cljc
@@ -24,10 +24,12 @@
 
   (retract-facts-logical! [listener node token facts]
     (do
-      (println "auto-retracting (no longer supported):" facts)
       (doseq [fact facts]
         (when-let [failed-to-remove? (some false? (util/remove-fact-from-index! fact))]
-          (println "Failed to remove " fact)))
+          (throw (ex-info "Failed to remove logical retraction. This is not expected behavior and
+          may result in unexpected schema-based truth maintenence. If you continue to see
+          this error, please file an issue at https://github.com/CoNarrative/precept/issues."
+                   {:fact fact}))))
       (append-trace listener {:type :retract-facts-logical :facts facts})))
 
   (to-persistent! [listener]

--- a/src/clj/precept/schema.cljc
+++ b/src/clj/precept/schema.cljc
@@ -53,8 +53,8 @@
      :db/unique :db.unique/identity)
 
    (attribute ::sub/response
-     :db.type/any
-     :db/unique :db.unique/identity)
+     :db.type/any)
+     ;:db/unique :db.unique/identity)
 
    (attribute :entities/eid
      :db.type/any

--- a/src/clj/precept/schema.cljc
+++ b/src/clj/precept/schema.cljc
@@ -53,8 +53,8 @@
      :db/unique :db.unique/identity)
 
    (attribute ::sub/response
-     :db.type/any)
-     ;:db/unique :db.unique/identity)
+     :db.type/any
+     :db/unique :db.unique/identity)
 
    (attribute :entities/eid
      :db.type/any

--- a/src/clj/precept/spec/fact.cljc
+++ b/src/clj/precept/spec/fact.cljc
@@ -7,6 +7,6 @@
 
 (s/def ::tuple
   (s/tuple
-    some?
+    any?
     keyword?
-    some?))
+    any?))

--- a/src/clj/precept/spec/lang.cljc
+++ b/src/clj/precept/spec/lang.cljc
@@ -63,7 +63,7 @@
   (s/tuple
     (s/and some? #(not (s/valid? ::s-expr %)))
     any?
-    (s/and some? #(not (s/valid? ::s-expr %)))
+    (s/and any? #(not (s/valid? ::s-expr %)))
     (s/and some?
       (s/or :value-match-t number?
             :bind-to-t ::variable-binding))))

--- a/src/clj/precept/util.cljc
+++ b/src/clj/precept/util.cljc
@@ -246,11 +246,12 @@
   [facts]
   (let [[to-insert to-retract] (conform-insertions-and-retractions! facts)]
     (trace "[insert!] : inserting " to-insert)
-    (trace "[insert!] : retracting " to-retract)
+    (trace "[insert!] : conflicting " to-retract)
     (if (empty? to-retract)
       (cr/insert-all! to-insert)
-      (do (cr/insert-all! to-insert)
-          (doseq [x to-retract] (cr/retract! x))))))
+      (do
+        (println "Conflicting logical fact!" to-insert " is blocked by " to-retract)
+        (throw (ex-info "Conflicting logical fact!" {}))))))
 
 (defn insert-unconditional!
   "Insert facts unconditionally within rule context"

--- a/test/clj/precept/rule_test.cljc
+++ b/test/clj/precept/rule_test.cljc
@@ -418,25 +418,30 @@
   ;                    [?eids <- (acc/all :e) :from [:interesting-fact]]
   ;                    =>
   ;                    (let [req-id (precept.util/guid)]
-  ;                       (precept.util/insert-unconditional!
-  ;                         [[req-id ::rulegen/for-macro :entities]
+  ;                       (precept.util/insert!
+  ;                         [[req-id ::rulegen/for-rule my-rule]
+  ;                          [req-id ::rulegen/for-macro :entities]
   ;                          [req-id ::rulegen/request-params ?eids]
   ;                          [req-id :entities/order ?eids]])
   ;                       (doseq [eid ?eids]
-  ;                         (precept.util/insert-unconditional! [req-id :entities/eid eid])))))
+  ;                         (precept.util/insert! [req-id :entities/eid eid])))))
   ;
   ;        rule-2 (macroexpand
   ;                 '(defrule my-rule
-  ;                    [?eids <- (acc/all :e) :from [:interesting-fact]]
-  ;                    [::rulegen/request-params (= ?id (:e this)) (= ?eids (:v this))]
+  ;                    [:some-condition (= ?e (:e this)) (= true (:v this))]
+  ;                    [::rulegen/for-rule (= ?id (:e this)) (= my-rule (:v this))]
   ;                    [::rulegen/for-macro (= ?id (:e this)) (= :entities (:v this))]
+  ;                    [::rulegen/request-params (= ?id (:e this)) (= ?eids (:v this))]
   ;                    [::rulegen/response (= ?id (:e this)) (= ?interesting-facts (:v this))]
+  ;                    [:another-condition (= ?e (:e this)) (= false (:v this))]
   ;                    =>
   ;                    (println nil)))]
   ;    (is (= (macroexpand
   ;             '(rule my-rule
+  ;                [[?e :some-condiition true]]
   ;                [?eids <- (acc/all :e) :from [:interesting-fact]]
   ;                [(<- ?interesting-facts (entities ?eids))]
+  ;                [[?e :another-condition false]]
   ;                =>
   ;                (println nil)))
   ;           `(do ~rule-1 ~rule-2))))))

--- a/test/clj/precept/util_test.cljc
+++ b/test/clj/precept/util_test.cljc
@@ -331,11 +331,6 @@
       (is (= {:insert fact-1} (update-index! fact-1)))
       (is (= @state/fact-index {:one-to-one {1 {:foo fact-1}}})))
 
-    ; Removed because fact-id entails no 2 facts identical
-    ;(testing "Removing a fact that exists in index"
-    ;  (is (= {:retract fact-1} (remove-from-fact-index! fact-1 (fact-index-path fact-1))))
-    ;  (is (= @state/fact-index {})))
-
     (testing "Index same e-a one-to-one should upsert"
       (is (= @state/fact-index {:one-to-one {1 {:foo fact-1}}}))
       (is (= {:insert next-1 :retract fact-1} (update-index! next-1)))
@@ -454,6 +449,18 @@
                                ::test/unique-identity unique-upsert}
                             2 {::test/unique-value unique-value}}
                :unique {(:a unique-upsert) {(:v unique-upsert) unique-upsert}
-                        (:a unique-value) {(:v unique-value) unique-value}}}))))))
+                        (:a unique-value) {(:v unique-value) unique-value}}}))))
+
+    (testing "Remove one-to-one fact from cardinality index when identical match"
+      (let [_ (reset! state/fact-index {})
+            _ (update-index! fact-1)]
+        (is (= [true] (remove-fact-from-index! fact-1)))
+        (is (= @state/fact-index {}))))
+
+    (testing "Remove unique fact from cardinality, unique indices when identical match"
+      (let [_ (reset! state/fact-index {})
+            _ (update-index! unique)]
+        (is (= [true true] (remove-fact-from-index! unique)))
+        (is (= @state/fact-index {}))))))
 
 (run-tests)

--- a/test/clj/precept/util_test.cljc
+++ b/test/clj/precept/util_test.cljc
@@ -135,7 +135,7 @@
 
 (deftest insertable-test
   (testing "Single vector"
-    (let [rtn (insertable [-1 :attr "foo"])]
+    (let [rtn (insertable [-1 :attr nil])]
       (is (and (not (record? rtn)) (coll? rtn)))
       (is (every? #(= (type %) Tuple) rtn))))
   (testing "Vector of vectors"
@@ -309,8 +309,8 @@
   (let [h (schema/schema->hierarchy test-schema)
         _ (make-ancestors-fn h)
         fact-1 (->Tuple 1 :foo 42 1)
-        fact-2 (->Tuple 1 :bar 42 2)
         next-1 (->Tuple 1 :foo 43 3)
+        fact-2 (->Tuple 1 :bar 42 2)
         next-2 (->Tuple 1 :bar 43 4)
         one-to-many (->Tuple 1 ::test/one-to-many 42 5)
         unique (->Tuple 1 ::test/unique-identity "my unique title" 6)
@@ -319,44 +319,41 @@
         unique-value-conflicting (->Tuple 1 ::test/unique-value "foo" 9)
         unique-value-upsert (->Tuple 2 ::test/unique-value "bar" 10)
         unique-value (->Tuple 2 ::test/unique-value "foo" 11)]
-
+;; attempting to fix the bug approach
+;; when there is a one to one that is in the index (e a) remove itreplace it
     (testing "Initial state"
       (is (= {} (reset! state/fact-index {}))
           "Expected fact index to be {}")
       (is (fn? @state/ancestors-fn)
           "Expected ancestors-fn to be a fn"))
 
-    (testing "Finding existing with empty state"
-      (is (= {:insert fact-1} (add-to-fact-index! fact-1 (fact-index-path fact-1)))))
-
-    (testing "Fact is indexed by find-existing"
+    (testing "Index one-to-one with empty state"
+      (is (= {:insert fact-1} (update-index! fact-1)))
       (is (= @state/fact-index {:one-to-one {1 {:foo fact-1}}})))
 
-    (testing "Removing a fact that exists in index"
-      (is (= {:retract fact-1} (remove-from-fact-index! fact-1 (fact-index-path fact-1))))
-      (is (= @state/fact-index {})))
+    ; Removed because fact-id entails no 2 facts identical
+    ;(testing "Removing a fact that exists in index"
+    ;  (is (= {:retract fact-1} (remove-from-fact-index! fact-1 (fact-index-path fact-1))))
+    ;  (is (= @state/fact-index {})))
 
-    (testing "Newer one-to-one facts should return old fact"
-      (is (= @state/fact-index {}))
-      (is (= {:insert fact-1} (add-to-fact-index! fact-1 (fact-index-path fact-1))))
-      (is (= {:retract fact-1 :insert next-1}
-            (add-to-fact-index! next-1 (fact-index-path next-1)))))
-
-    (testing "Existing one-to-one-fact should have been replaced"
+    (testing "Index same e-a one-to-one should upsert"
+      (is (= @state/fact-index {:one-to-one {1 {:foo fact-1}}}))
+      (is (= {:insert next-1 :retract fact-1} (update-index! next-1)))
       (is (= @state/fact-index {:one-to-one {1 {:foo next-1}}})))
 
     (testing "Remove fact from index that does not exist"
       (is (= {:retract nil} (remove-from-fact-index! fact-1 (fact-index-path fact-1))))
       (is (= @state/fact-index {:one-to-one {1 {:foo next-1}}})))
 
-    (testing "Find with same entity, different attribute should index the new fact and return
-              nil (nothing to retract)"
+    (testing "Same eid, different attribute should index the new fact"
       (is (= @state/fact-index {:one-to-one {1 {:foo next-1}}}))
-      (is (= {:insert fact-2} (add-to-fact-index! fact-2 (fact-index-path fact-2))))
+      (is (= {:insert fact-2} (update-index! fact-2)))
       (is (= @state/fact-index {:one-to-one {1 {:foo next-1
                                                 :bar fact-2}}})))
 
-    (testing "Removing same entity, same attribute but different fact-id should not alter index and
+    ;; Check if this must be the case, seems like either 1. remove fn should just carry out instrs,
+    ;; 2. we remove if e-a pair matches (not whole fact)
+    (testing "Removing same eid, same attribute but different fact-id should not alter index and
               return false to indicate nothing was removed"
       (is (= @state/fact-index {:one-to-one {1 {:foo next-1
                                                 :bar fact-2}}}))
@@ -367,9 +364,8 @@
     (testing "One-to-many attrs do not affect fact index"
       (is (= @state/fact-index {:one-to-one {1 {:foo next-1
                                                 :bar fact-2}}}))
-      (is (= {:insert one-to-many}
-             (add-to-fact-index! one-to-many (fact-index-path one-to-many))))
-      (is (= {:retract nil} (remove-from-fact-index! one-to-many (fact-index-path one-to-many))))
+      (is (= (update-index! one-to-many)
+             {:insert one-to-many}))
       (is (= @state/fact-index {:one-to-one {1 {:foo next-1
                                                 :bar fact-2}}})))
 


### PR DESCRIPTION
In addition to issues outlined in #91:
- Fixed bug introduced in #84 that prevented facts with a value slot of `nil` from being converted to Tuple records
- Added fn that remove a fact from all indexes and returns information about successful removal
- Use added fn in change listener to remove facts from our indexes when there is a retraction that results from an insert-logical operation
- Throw error when a logical insertion will result in a violation of the schema
- Rewrote rule generation for `entities` macro to prevent using the same accumulator twice in two different rules (appears to share a node and result in logical retractions occurring later than they should)