### PR TITLE
Support clara-rules 0.17.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/spec.alpha "0.1.109"]
                  [org.clojure/clojurescript "1.9.854"]
                  [org.clojure/core.async "0.3.442"]
-                 [com.cerner/clara-rules "0.16.0-SNAPSHOT"]
+                 [com.cerner/clara-rules "0.17.0"]
                  [com.cognitect/transit-clj "0.8.300"]
                  [com.cognitect/transit-cljs "0.8.239"]
                  [com.taoensso/sente "1.11.0"]

--- a/src/cljc/precept/rules.cljc
+++ b/src/cljc/precept/rules.cljc
@@ -16,6 +16,7 @@
                        [precept.schema :as schema]
                        [precept.core :as core]
                        [precept.accumulators]
+                       [precept.impl.rules]
                        [precept.state :as state]))
     #?(:cljs (:require-macros precept.rules precept.repl)))
 
@@ -85,8 +86,8 @@
      `:activation-group-sort-fn` - `(util/make-activation-group-fn [:action :calc :report :cleanup])`
        Determines the scheme by which some rules are given priority over others. Rules in the
        `:action` group will be given the chance to fire before rules in the `:calc` group and so on.
-       When determining the priority of two rules are in the same group, the :salience property
-       serves as a tiebreaker, with higher salience rules winning over lower salience ones."
+       When determining the priority of two rules in the same group, the :salience property
+       serves as a tiebreaker, with higher salience rules receiving precedence over lower salience ones."
      [name & sources-and-options]
      (if (compiling-cljs?)
        `(precept.macros/session ~name ~@sources-and-options)


### PR DESCRIPTION
Choosing to make this part of 0.5.0 release so merging into issue-19 branch to avoid divergence. 

- Upgrade clara-rules to 0.17.0
- Fixes impl rules not being loaded which broke entities macro implementation and the removal of `:transient` facts at end of `fire-rules` (#112)
- Fixes missing references to functions declared in rule namespaces in CLJS (#111, [clara-rules #359](https://github.com/cerner/clara-rules/issues/359))

Commits in the devtools repo (currently unpublished) depend on these changes as of devtools commit e4606aa028d27ec9b5ae3a32023f381f3ea16774.